### PR TITLE
Fix the default TG expire

### DIFF
--- a/src/peers.rs
+++ b/src/peers.rs
@@ -69,7 +69,7 @@ impl Peer {
             peer_type: Peertype::Local,
             rx_bytes: 0,
             slot: slot::Slot::init(),
-            tg_expire: 0,
+            tg_expire: 15,
         }
     }
 


### PR DESCRIPTION
If no options are sent, then the default TG expire is 0. This really should be set to 15 minutes.